### PR TITLE
Fix build script for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && copy nodes\\Signal\\signal.svg dist\\nodes\\Signal\\signal.svg && copy credentials\\signal.svg dist\\credentials\\signal.svg",
+    "build": "tsc && copyfiles nodes/Signal/signal.svg credentials/signal.svg dist",
     "dev": "tsc --watch",
     "prepublishOnly": "npm run build"
   },
@@ -36,10 +36,11 @@
     "n8n-workflow": ">=1.109.0"
   },
   "devDependencies": {
-    "n8n-workflow": "1.109.0",
-    "typescript": "^5.4.5",
     "@types/node": "^20.12.12",
-    "@types/ws": "^8.5.12"
+    "@types/ws": "^8.5.12",
+    "copyfiles": "^2.4.1",
+    "n8n-workflow": "1.109.0",
+    "typescript": "^5.4.5"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Replaces Windows-specific `copy` commands with the cross-platform `copyfiles` package to ensure the build script works on both macOS and Windows.