### PR TITLE
Fix wrong expression syntax in credential test

### DIFF
--- a/credentials/SignalApi.credentials.ts
+++ b/credentials/SignalApi.credentials.ts
@@ -40,10 +40,7 @@ export class SignalApi implements ICredentialType {
             method: 'GET',
             url: '={{$credentials.apiUrl}}/v1/about',
             headers: {
-                // The Authorization header uses n8n expression syntax for runtime interpolation
-                ...(typeof '{{ $credentials.apiToken }}' === 'string' && '{{ $credentials.apiToken }}'
-                    ? { Authorization: 'Bearer {{ $credentials.apiToken }}' }
-                    : {}),
+                Authorization: '={{$credentials.apiToken ? "Bearer " + $credentials.apiToken : ""}}',
             },
             timeout: 5000,
         }


### PR DESCRIPTION
Corrects the credential test that was sending the string `Bearer {{ $credentials.apiToken }}` literally, which resulted in an error instead of properly evaluating the n8n expression.

This correctly evaluates the credential value at runtime and constructs the Bearer token, or sends an empty string if no token is provided.